### PR TITLE
FEAT - preface and postface excluded from TOC

### DIFF
--- a/pandoc/templates/eisvogel.latex
+++ b/pandoc/templates/eisvogel.latex
@@ -680,6 +680,15 @@ $endif$
 %% end added
 %%
 
+%
+% Commands to disable and enable section writing to table of contents
+% Taken from https://tex.stackexchange.com/questions/214131/exclude-appendix-sections-subsections-and-subsubsection-from-toc
+%
+\newcommand{\stoptocwriting}{%
+  \addtocontents{toc}{\protect\setcounter{tocdepth}{-5}}}
+\newcommand{\resumetocwriting}{%
+  \addtocontents{toc}{\protect\setcounter{tocdepth}{\arabic{tocdepth}}}}
+
 \begin{document}
 
 %%
@@ -743,8 +752,12 @@ $abstract$
 $endif$
 $endif$
 
+% Disable TOC writing for include-befores
+\stoptocwriting
 $for(include-before)$
 $include-before$
+% Resume TOC writing
+\resumetocwriting
 
 $endfor$
 $if(toc)$
@@ -814,8 +827,12 @@ $else$
 $endif$
 
 $endif$
+% Disable TOC writing for include-afters
+\stoptocwriting
 $for(include-after)$
 $include-after$
+% Resume writing TOC
+\resumetocwriting
 
 $endfor$
 \end{document}


### PR DESCRIPTION
- added commands to exclude items from TOC `\stoptocwriting` & `\resumetocwriting`; and
- excluded pandoc `include-before` & `include-after` elements from TOC.

For source of LaTeX TOC macro see: https://tex.stackexchange.com/questions/214131/exclude-appendix-sections-subsections-and-subsubsection-from-toc