### PR TITLE
FIX - temp directory virtualenv on demand

### DIFF
--- a/utils/create-venv.sh
+++ b/utils/create-venv.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
-if [ ! -d .venv/markdown/ ]
-then
-  virtualenv -p python3 .venv/markdown
-  source .venv/markdown/bin/activate
-  pip install markdownPP
-  deactivate
-fi
+# Conditional check to see if markdownPP is installed
+# Acknowledgements to https://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script
+command -v markdown-pp >/dev/null 2>&1 || {
+  # IF no markdown-pp command
+  # Grab the temp directory name
+  # Acknowledgements to https://unix.stackexchange.com/questions/174817/finding-the-correct-tmp-dir-on-multiple-platforms
+  tmpdir=$(dirname $(mktemp -u))
+  if [ ! -d "$tmpdir/.venv-markdown/" ]
+  then
+    # IF no virtualenv exists
+    virtualenv -p python3 "$tmpdir/.venv-markdown"
+    source "$tmpdir/.venv-markdown/bin/activate"
+    pip install markdownPP
+  fi
+}


### PR DESCRIPTION
- virtualenv now only created if no markdown-pp command found:
  - See https://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script; and
- virtualenv created in the temp directory when required:
  - See https://unix.stackexchange.com/questions/174817/finding-the-correct-tmp-dir-on-multiple-platforms.