### PR TITLE
FIX - Namespace declarations in examples

### DIFF
--- a/src/main/java/eu/dilcis/csip/out/XmlFormatter.java
+++ b/src/main/java/eu/dilcis/csip/out/XmlFormatter.java
@@ -1,8 +1,10 @@
 package eu.dilcis.csip.out;
 
 import java.util.Arrays;
+import java.util.Enumeration;
 
 import org.xml.sax.Attributes;
+import org.xml.sax.helpers.NamespaceSupport;
 
 /**
  * @author  <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
@@ -33,22 +35,53 @@ enum XmlFormatter {
 		return new String(chars);
 	}
 
-	static String eleStartTag(final String eleName, final Attributes attrs) {
+	static String eleStartTag(final String eleName, final Attributes attrs, final NamespaceSupport namespaces) {
 		StringBuffer retVal = makeEleTag(eleName, false);
+		if ("mets:mets".equals(eleName)) {
+			addNsDecs(retVal, namespaces);
+		}
+
 		if (attrs != null) {
 			for (int i = 0; i < attrs.getLength(); i++) {
-				String aName = attrs.getLocalName(i); // Attr name
+				String aName = attrs.getQName(i); // Attr name
 				if (empty.equals(aName))
-					aName = attrs.getQName(i);
-				retVal.append(space);
-				retVal.append(aName);
-				retVal.append(attOpen);
-				retVal.append(attrs.getValue(i));
-				retVal.append(attClose);
+					aName = attrs.getLocalName(i);
+				eleAttribute(retVal, aName, attrs.getValue(i));
 			}
 		}
-		retVal.append(eleClose);
-		return retVal.toString();
+		return retVal.append(eleClose).toString();
+	}
+
+	static StringBuffer addNsDecs(final StringBuffer buff, final NamespaceSupport namespaces) {
+		for (Enumeration<String> prefixs = namespaces.getPrefixes(); prefixs.hasMoreElements();) {
+			final String prefix = prefixs.nextElement();
+			if ("xml".equals(prefix)) {
+				continue;
+			}
+			eleAttribute(buff, "xmlns:" + prefix, namespaces.getURI(prefix));
+		}
+		return buff;
+	}
+
+	static StringBuffer addAttributes(final StringBuffer buff, final Attributes attrs) {
+		if (attrs != null) {
+			for (int i = 0; i < attrs.getLength(); i++) {
+				String aName = attrs.getQName(i); // Attr name
+				if (empty.equals(aName))
+					aName = attrs.getLocalName(i);
+				eleAttribute(buff, aName, attrs.getValue(i));
+			}
+		}
+		return buff;
+	}
+
+	private static StringBuffer eleAttribute(final StringBuffer buff, final String attName, final String attValue) {
+		buff.append(space);
+		buff.append(attName);
+		buff.append(attOpen);
+		buff.append(attValue);
+		buff.append(attClose);
+		return buff;
 	}
 
 	static String eleEndTag(final String eleName) {

--- a/src/main/java/eu/dilcis/csip/out/XmlFragmentGenerator.java
+++ b/src/main/java/eu/dilcis/csip/out/XmlFragmentGenerator.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import org.xml.sax.Attributes;
+import org.xml.sax.helpers.NamespaceSupport;
 
 /**
  * Abstract class to handle the pain of XML element generation, e.g.
@@ -57,11 +58,11 @@ abstract class XmlFragmentGenerator {
 		this.indent = indent;
 	}
 
-	public void outputEleStart(final String eleName, final Attributes attrs)
+	public void outputEleStart(final String eleName, final Attributes attrs, final NamespaceSupport namespaces)
 			throws IOException {
 		this.handler.nl();
 		this.indent();
-		this.handler.emit(XmlFormatter.eleStartTag(eleName, attrs));
+		this.handler.emit(XmlFormatter.eleStartTag(eleName, attrs, namespaces));
 		this.indent++;
 	}
 


### PR DESCRIPTION
- thread `NamespaceSupport` object through calls to handle namespaces;
- added namespace declarations to root elements in examples;
- added namespace prefixes to attributes; and
- refactored some of the XML output routines for tidiness.