### PR TITLE
FIX: Remove front page logo

### DIFF
--- a/pandoc/templates/eisvogel.latex
+++ b/pandoc/templates/eisvogel.latex
@@ -724,11 +724,6 @@ $endif$
 \vfill
 }
 
-$if(logo)$
-\noindent
-\includegraphics[width=$if(logo-width)$$logo-width$$else$100$endif$pt, left]{$logo$}
-$endif$
-
 Date: \textsf{$date$}}\\
 Version: $version$
 \end{flushleft}


### PR DESCRIPTION
- removed logo generation from `pandoc/templates/eisvogel.latex`.