### PR TITLE
REL: v0.2.0

### DIFF
--- a/pandoc/templates/eisvogel.latex
+++ b/pandoc/templates/eisvogel.latex
@@ -511,7 +511,7 @@ $endif$
 \usepackage[font={stretch=1.2}, textfont={color=caption-color}, position=top, skip=4mm, labelfont=bf, singlelinecheck=false, justification=$if(caption-justification)$$caption-justification$$else$raggedright$endif$]{caption}
 \setcapindent{0em}
 \captionsetup[longtable]{position=above}
-
+\renewcommand \caption [2][]{}
 %
 % blockquote
 %

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.dilcis</groupId>
 	<artifactId>eark-csip-profile-processor</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<name>E-ARK CSIP METS Profile processor</name>
 	<description>SAX parser to generate Markdown requirement tables from the E-ARK CSIP METS Profile.</description>
 

--- a/res/md/common-intro.md
+++ b/res/md/common-intro.md
@@ -8,7 +8,7 @@ A visualisation of the current specification network can be seen here:
 <a name="figi-dip"></a>
 ![OAIS Entities](figs/fig_1_dip.png "Diagram showing E-ARK specification dependency hierarchy")
 
-**Figure I:** Diagram showing E-ARK specification dependency hierarchy. Note that the image only shows a selection of the published CITS and isn't an exhaustive list.
+**Figure 1:** Diagram showing E-ARK specification dependency hierarchy. Note that the image only shows a selection of the published CITS and isn't an exhaustive list.
 
 ### Overview of the E-ARK Specifications
 

--- a/src/main/java/eu/dilcis/csip/profile/Appendix.java
+++ b/src/main/java/eu/dilcis/csip/profile/Appendix.java
@@ -7,12 +7,37 @@ import java.util.Objects;
 import org.xml.sax.Attributes;
 
 public final class Appendix {
+    static final class Builder extends XmlFragmentGenerator {
+        private int number;
+        private String label;
+
+        Builder(final Attributes attributes) {
+            this.number = Integer.valueOf(Utilities.getNumber(attributes));
+            this.label = (Utilities.getLabel(attributes));
+        }
+
+        Builder number(final int number) {
+            this.number = number;
+            return this;
+        }
+
+        Builder label(final String label) {
+            this.label = label;
+            return this;
+        }
+
+        Appendix build() {
+            return Appendix.fromValues(number, label, content);
+        }
+    }
+
     public static Appendix fromValues(final int number, final String label, final List<String> content) {
         return new Appendix(number, label, content);
     }
 
     public final int number;
     public final String label;
+
     public final List<String> content;
 
     private Appendix(final int number, final String label, final List<String> content) {
@@ -34,29 +59,5 @@ public final class Appendix {
             return false;
         final Appendix other = (Appendix) obj;
         return number == other.number && Objects.equals(label, other.label) && Objects.equals(content, other.content);
-    }
-
-    static final class Builder extends XmlFragmentGenerator {
-        private int number;
-        private String label;
-
-        Builder(Attributes attributes) {
-            this.number = Integer.valueOf(Utilities.getNumber(attributes));
-            this.label = (Utilities.getLabel(attributes));
-        }
-
-        Builder number(final int number) {
-            this.number = number;
-            return this;
-        }
-
-        Builder label(final String label) {
-            this.label = label;
-            return this;
-        }
-
-        Appendix build() {
-            return Appendix.fromValues(number, label, content);
-        }
     }
 }

--- a/src/main/java/eu/dilcis/csip/profile/ControlledVocabulary.java
+++ b/src/main/java/eu/dilcis/csip/profile/ControlledVocabulary.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author  <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
@@ -71,7 +72,25 @@ public final class ControlledVocabulary {
 			return new ControlledVocabulary(this.ident, this.nm, this.mntnceAgncy, this.ri, this.cntxt, this.desc);
 		}
 	}
-	public final String id;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, maintenanceAgency, uri, context);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof ControlledVocabulary))
+            return false;
+        ControlledVocabulary other = (ControlledVocabulary) obj;
+        return Objects.equals(id, other.id) && Objects.equals(name, other.name)
+                && Objects.equals(maintenanceAgency, other.maintenanceAgency) && Objects.equals(uri, other.uri)
+                && Objects.equals(context, other.context);
+    }
+
+    public final String id;
 	public final String name;
 	public final String maintenanceAgency;
 	public final URI uri;

--- a/src/main/java/eu/dilcis/csip/profile/Example.java
+++ b/src/main/java/eu/dilcis/csip/profile/Example.java
@@ -1,39 +1,41 @@
 package eu.dilcis.csip.profile;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.xml.sax.Attributes;
 
 public final class Example {
-    final String id;
-    final String label;
-    final List<String> content;
-
-    private Example(String id, String label, List<String> content) {
-        this.id = id;
-        this.label = label;
-        this.content = content;
-    }
-
-    static Example fromValues(String id, String label, List<String> content) {
-        return new Example(id, label, content);
-    }
-
     static class Builder extends XmlFragmentGenerator {
         private String id;
         private String label;
 
-        Builder(Attributes attributes) {
+        Builder(final Attributes attributes) {
             this.id = Utilities.getId(attributes);
             this.label = Utilities.getLabel(attributes);
         }
 
-        Builder id(String id) {
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, label);
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            if (this == obj)
+                return true;
+            if (!(obj instanceof Builder))
+                return false;
+            final Builder other = (Builder) obj;
+            return Objects.equals(id, other.id) && Objects.equals(label, other.label);
+        }
+
+        Builder id(final String id) {
             this.id = id;
             return this;
         }
 
-        Builder label(String label) {
+        Builder label(final String label) {
             this.label = label;
             return this;
         }
@@ -41,5 +43,37 @@ public final class Example {
         Example build() {
             return Example.fromValues(id, label, content);
         }
+    }
+
+    static Example fromValues(final String id, final String label, final List<String> content) {
+        return new Example(id, label, content);
+    }
+
+    final String id;
+
+    final String label;
+
+    final List<String> content;
+
+    private Example(final String id, final String label, final List<String> content) {
+        this.id = id;
+        this.label = label;
+        this.content = content;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, label, content);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof Example))
+            return false;
+        final Example other = (Example) obj;
+        return Objects.equals(id, other.id) && Objects.equals(label, other.label)
+                && Objects.equals(content, other.content);
     }
 }

--- a/src/main/java/eu/dilcis/csip/profile/ExternalSchema.java
+++ b/src/main/java/eu/dilcis/csip/profile/ExternalSchema.java
@@ -4,73 +4,91 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
- * @author  <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
- *          <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
  *
  * @version 0.1
  * 
- * Created 19 Nov 2018:23:24:31
+ *          Created 19 Nov 2018:23:24:31
  */
 
 public final class ExternalSchema {
-	public static class Builder {
-		private String nm = Constants.EMPTY;
-		private URI rl = URI.create(Constants.DEFAULT_URI);
-		private String cntxt = Constants.EMPTY;
-		private List<String> nt = new ArrayList<>();
+    public static class Builder {
+        private String nm = Constants.EMPTY;
+        private URI rl = URI.create(Constants.DEFAULT_URI);
+        private String cntxt = Constants.EMPTY;
+        private List<String> nt = new ArrayList<>();
 
-		public Builder() {
-			super();
-		}
+        public Builder() {
+            super();
+        }
 
-		public Builder name(final String name) {
-			this.nm = name;
-			return this;
-		}
+        public Builder name(final String name) {
+            this.nm = name;
+            return this;
+        }
 
-		public Builder url(final URI url) {
-			this.rl = url.normalize();
-			return this;
-		}
+        public Builder url(final URI url) {
+            this.rl = url.normalize();
+            return this;
+        }
 
-		public Builder url(final String url) {
-			this.rl = URI.create(url);
-			return this;
-		}
+        public Builder url(final String url) {
+            this.rl = URI.create(url);
+            return this;
+        }
 
-		public Builder context(final String context) {
-			this.cntxt = context;
-			return this;
-		}
+        public Builder context(final String context) {
+            this.cntxt = context;
+            return this;
+        }
 
-		public Builder note(final String note) {
-			this.nt.add(note);
-			return this;
-		}
+        public Builder note(final String note) {
+            this.nt.add(note);
+            return this;
+        }
 
-		public Builder notes(final List<String> notes) {
-			this.nt = new ArrayList<>(notes);
-			return this;
-		}
-		
-		public ExternalSchema build( ) {
-			return new ExternalSchema(this.nm, this.rl, this.cntxt, this.nt);
-		}
-	}
-	public final String name;
-	public final URI url;
-	public final String context;
+        public Builder notes(final List<String> notes) {
+            this.nt = new ArrayList<>(notes);
+            return this;
+        }
 
-	public final List<String> note;
+        public ExternalSchema build() {
+            return new ExternalSchema(this.nm, this.rl, this.cntxt, this.nt);
+        }
+    }
 
-	ExternalSchema(final String name, final URI url, final String context,
-			final List<String> note) {
-		super();
-		this.name = name;
-		this.url = url;
-		this.context = context;
-		this.note = Collections.unmodifiableList(note);
-	}
+    public final String name;
+    public final URI url;
+    public final String context;
+
+    public final List<String> note;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, url, context);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof ExternalSchema))
+            return false;
+        ExternalSchema other = (ExternalSchema) obj;
+        return Objects.equals(name, other.name) && Objects.equals(url, other.url)
+                && Objects.equals(context, other.context);
+    }
+
+    ExternalSchema(final String name, final URI url, final String context,
+            final List<String> note) {
+        super();
+        this.name = name;
+        this.url = url;
+        this.context = context;
+        this.note = Collections.unmodifiableList(note);
+    }
 }

--- a/src/main/java/eu/dilcis/csip/profile/MetsProfile.java
+++ b/src/main/java/eu/dilcis/csip/profile/MetsProfile.java
@@ -26,7 +26,8 @@ public final class MetsProfile {
 
     public static MetsProfile fromValues(final Details details, final List<Details> relatedProfiles,
             final List<Requirement> requirements, final Map<String, Example> examples,
-            final List<Appendix> appendices, final List<ExternalSchema> schemas, final List<ControlledVocabulary> vocabularies) {
+            final List<Appendix> appendices, final List<ExternalSchema> schemas,
+            final List<ControlledVocabulary> vocabularies) {
         return new MetsProfile(details, relatedProfiles, requirements, examples, appendices, schemas, vocabularies);
     }
 
@@ -48,10 +49,10 @@ public final class MetsProfile {
         this.relatedProfiles = relatedProfiles;
         this.orderedRequirements = requirements.stream().map(r -> r.id).collect(Collectors.toList());
         this.requirements = requirements.stream().collect(Collectors.toMap(r -> r.id, r -> r));
-        this.examples = examples;
-        this.appendices = appendices;
-        this.schemas = schemas;
-        this.vocabularies = vocabularies;
+        this.examples = Collections.unmodifiableMap(null == examples ? Map.of() : examples);
+        this.appendices = Collections.unmodifiableList(null == appendices ? List.of() : appendices);
+        this.schemas = Collections.unmodifiableList(null == schemas ? List.of() : schemas);
+        this.vocabularies = Collections.unmodifiableList(null == vocabularies ? List.of() : vocabularies);
     }
 
     public final List<Requirement> getRequirements() {

--- a/src/main/java/eu/dilcis/csip/profile/Profiles.java
+++ b/src/main/java/eu/dilcis/csip/profile/Profiles.java
@@ -21,8 +21,11 @@ public class Profiles {
         final Set<Example> examples = new HashSet<>();
         for (final Requirement requirement : requirements) {
             for (final MetsProfile profile : profiles) {
-                for (final String exampleId : requirement.examples) {
-                    examples.add(profile.getExampleById(exampleId));
+                if (profile.getRequirementById(requirement.id) != null) {
+                    for (final String exampleId : requirement.examples) {
+                        Example example = profile.getExampleById(exampleId);
+                        examples.add(example);
+                    }
                 }
             }
         }

--- a/src/main/java/eu/dilcis/csip/structure/MetsSource.java
+++ b/src/main/java/eu/dilcis/csip/structure/MetsSource.java
@@ -6,8 +6,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import eu.dilcis.csip.profile.Appendix;
 import eu.dilcis.csip.profile.ControlledVocabulary;
@@ -76,7 +78,7 @@ final class MetsSource extends Source {
     }
 
     private void serialiseAppendices(final Writer dest, final Map<String, Object> context) throws IOException {
-        final List<Appendix> appendices = new ArrayList<>();
+        final Set<Appendix> appendices = new HashSet<>();
         for (final MetsProfile profile : this.profiles) {
             appendices.addAll(profile.getAppendices());
         }
@@ -85,7 +87,7 @@ final class MetsSource extends Source {
     }
 
     private void serialiseExternalSchema(final Writer dest, final Map<String, Object> context) throws IOException {
-        final List<ExternalSchema> schema = new ArrayList<>();
+        final Set<ExternalSchema> schema = new HashSet<>();
         for (final MetsProfile profile : this.profiles) {
             schema.addAll(profile.getSchema());
         }
@@ -94,7 +96,7 @@ final class MetsSource extends Source {
     }
 
     private void serialiseVocabs(final Writer dest, final Map<String, Object> context) throws IOException {
-        final List<ControlledVocabulary> vocabularies = new ArrayList<>();
+        final Set<ControlledVocabulary> vocabularies = new HashSet<>();
         for (final MetsProfile profile : this.profiles) {
             vocabularies.addAll(profile.getVocabularies());
         }


### PR DESCRIPTION
- refactored specification serialisation:
  - dual loop for PDF and site now a single function with parameters;
  - examples are now looked up by requirement id and example id to cope with multiple profiles;
  - appendices, schemas and vocabularies now have `hashCode` and `equals` methods so that `Set<>` cand be used to avoid duplicates;
- turned off captioning of figures in the PDF;
- fixed the figure number for the first figure in the common introduction; and
- bumped version to 0.2.0-SNAPSHOT.